### PR TITLE
Increasing robustness regarding token issuers.

### DIFF
--- a/src/Collector.Common.RestClient/Collector.Common.RestClient.csproj
+++ b/src/Collector.Common.RestClient/Collector.Common.RestClient.csproj
@@ -5,7 +5,7 @@
     <PackageId>Collector.Common.RestClient</PackageId>
     <Company>Collector Bank AB</Company>
     <Product>Collector.Common.RestClient</Product>
-    <Version>15.0.0</Version>
+    <Version>15.0.1</Version>
     <Description>Rest API client to use with RestContracts and RestApi</Description>
     <Authors>Team Houdini, Team Heimdal</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
Adding a grace period where the old oauth2 token is still valid, but we try to get a new token anyway. This is to be more robust if the issuer of tokens goes offline. US#28269