### PR TITLE
Handle get parameters for arrays correctly

### DIFF
--- a/Collector.Common.RestClient.sln
+++ b/Collector.Common.RestClient.sln
@@ -1,19 +1,15 @@
-﻿
+﻿﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Collector.Common.RestClient", "src\Collector.Common.RestClient\Collector.Common.RestClient.csproj", "{5D15908D-91FC-43DB-B554-CA54794BBE42}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Collector.Common.RestClient", "src\Collector.Common.RestClient\Collector.Common.RestClient.csproj", "{5D15908D-91FC-43DB-B554-CA54794BBE42}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Collector.Common.RestClient.UnitTests", "test\Collector.Common.RestClient.Unittests\Collector.Common.RestClient.UnitTests.csproj", "{FF257B49-05AC-40A3-975E-FD5C021B4A0A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Collector.Common.RestClient.UnitTests", "test\Collector.Common.RestClient.Unittests\Collector.Common.RestClient.UnitTests.csproj", "{FF257B49-05AC-40A3-975E-FD5C021B4A0A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0B89F51D-0F3F-4E48-8CA7-DC71E0223AC2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{804C9A6D-343C-42D3-80B8-C3B4884F9B7C}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{031D9E31-FAD3-4FA0-A1F3-3A12F4C6ED07}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleExample", "examples\ConsoleExample\ConsoleExample.csproj", "{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,10 +25,6 @@ Global
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -40,9 +32,5 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5D15908D-91FC-43DB-B554-CA54794BBE42} = {0B89F51D-0F3F-4E48-8CA7-DC71E0223AC2}
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A} = {804C9A6D-343C-42D3-80B8-C3B4884F9B7C}
-		{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2} = {031D9E31-FAD3-4FA0-A1F3-3A12F4C6ED07}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {45427CF4-C926-4411-979A-4B14DEF19B1C}
 	EndGlobalSection
 EndGlobal

--- a/Collector.Common.RestClient.sln
+++ b/Collector.Common.RestClient.sln
@@ -1,5 +1,4 @@
-﻿﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/Collector.Common.RestClient.sln
+++ b/Collector.Common.RestClient.sln
@@ -1,4 +1,4 @@
-﻿﻿
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.15
@@ -10,6 +10,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0B89F51D-0F3F-4E48-8CA7-DC71E0223AC2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{804C9A6D-343C-42D3-80B8-C3B4884F9B7C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{4863354E-C83C-4C4F-94BF-31D20C182ADA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleExample", "examples\ConsoleExample\ConsoleExample.csproj", "{B0FE6648-D30B-4437-806B-D74BA6B4BCD2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContractsExamples", "examples\ContractsExamples\ContractsExamples.csproj", "{FBCC51AD-F28E-4242-A11F-B59ADEFA6A94}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,6 +31,14 @@ Global
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B0FE6648-D30B-4437-806B-D74BA6B4BCD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0FE6648-D30B-4437-806B-D74BA6B4BCD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0FE6648-D30B-4437-806B-D74BA6B4BCD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0FE6648-D30B-4437-806B-D74BA6B4BCD2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBCC51AD-F28E-4242-A11F-B59ADEFA6A94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBCC51AD-F28E-4242-A11F-B59ADEFA6A94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBCC51AD-F28E-4242-A11F-B59ADEFA6A94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBCC51AD-F28E-4242-A11F-B59ADEFA6A94}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -32,5 +46,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5D15908D-91FC-43DB-B554-CA54794BBE42} = {0B89F51D-0F3F-4E48-8CA7-DC71E0223AC2}
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A} = {804C9A6D-343C-42D3-80B8-C3B4884F9B7C}
+		{B0FE6648-D30B-4437-806B-D74BA6B4BCD2} = {4863354E-C83C-4C4F-94BF-31D20C182ADA}
+		{FBCC51AD-F28E-4242-A11F-B59ADEFA6A94} = {4863354E-C83C-4C4F-94BF-31D20C182ADA}
 	EndGlobalSection
 EndGlobal

--- a/Collector.Common.RestClient.sln
+++ b/Collector.Common.RestClient.sln
@@ -1,4 +1,5 @@
-﻿﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/Collector.Common.RestClient.sln
+++ b/Collector.Common.RestClient.sln
@@ -3,13 +3,17 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Collector.Common.RestClient", "src\Collector.Common.RestClient\Collector.Common.RestClient.csproj", "{5D15908D-91FC-43DB-B554-CA54794BBE42}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Collector.Common.RestClient", "src\Collector.Common.RestClient\Collector.Common.RestClient.csproj", "{5D15908D-91FC-43DB-B554-CA54794BBE42}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Collector.Common.RestClient.UnitTests", "test\Collector.Common.RestClient.Unittests\Collector.Common.RestClient.UnitTests.csproj", "{FF257B49-05AC-40A3-975E-FD5C021B4A0A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Collector.Common.RestClient.UnitTests", "test\Collector.Common.RestClient.Unittests\Collector.Common.RestClient.UnitTests.csproj", "{FF257B49-05AC-40A3-975E-FD5C021B4A0A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0B89F51D-0F3F-4E48-8CA7-DC71E0223AC2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{804C9A6D-343C-42D3-80B8-C3B4884F9B7C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{031D9E31-FAD3-4FA0-A1F3-3A12F4C6ED07}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleExample", "examples\ConsoleExample\ConsoleExample.csproj", "{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,6 +29,10 @@ Global
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -32,5 +40,9 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5D15908D-91FC-43DB-B554-CA54794BBE42} = {0B89F51D-0F3F-4E48-8CA7-DC71E0223AC2}
 		{FF257B49-05AC-40A3-975E-FD5C021B4A0A} = {804C9A6D-343C-42D3-80B8-C3B4884F9B7C}
+		{C17DEC69-1DFD-47BE-B2AA-6171B9ADE3D2} = {031D9E31-FAD3-4FA0-A1F3-3A12F4C6ED07}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {45427CF4-C926-4411-979A-4B14DEF19B1C}
 	EndGlobalSection
 EndGlobal

--- a/Collector.Common.RestClient.sln.DotSettings
+++ b/Collector.Common.RestClient.sln.DotSettings
@@ -30,7 +30,6 @@
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_USER_LINEBREAKS/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
@@ -470,11 +469,9 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>

--- a/Collector.Common.RestClient.sln.DotSettings
+++ b/Collector.Common.RestClient.sln.DotSettings
@@ -30,6 +30,7 @@
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_USER_LINEBREAKS/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
@@ -469,9 +470,11 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>

--- a/examples/ConsoleExample/ConsoleExample.csproj
+++ b/examples/ConsoleExample/ConsoleExample.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Collector.Common.RestClient\Collector.Common.RestClient.csproj" />
+    <ProjectReference Include="..\ContractsExamples\ContractsExamples.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/ConsoleExample/Program.cs
+++ b/examples/ConsoleExample/Program.cs
@@ -1,0 +1,71 @@
+﻿namespace ConsoleExample
+{
+    using Collector.Common.RestClient;
+
+    using System;
+    using System.Linq;
+
+    using ContractsExamples.github.UserDetails;
+    using ContractsExamples.github.Users;
+
+    using Microsoft.Extensions.Configuration;
+
+    class Program
+    {
+        private static readonly string PerformedBy = typeof(Program).Namespace;
+        private static IRestApiClient _client;
+
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello ConsoleExample!");
+            
+            SetupRestClient();
+
+            Console.WriteLine("Make a GET against the github /users end point");
+
+            var users = GetGithubUsers();
+            foreach (var user in users)
+            {
+                Console.WriteLine("Login: " + user.Login);
+            }
+
+            Console.WriteLine("Get details for a random user...");
+            var randomUser = users.OrderBy(x => Guid.NewGuid().ToString()).First();
+
+            var details = GetUserDetailsResponse(randomUser.Login);
+
+            Console.WriteLine("Details name: " + details.Name);
+            Console.WriteLine("Details login: " + details.Login);
+
+            Console.ReadKey();
+        }
+
+        private static UsersResponse[] GetGithubUsers()
+        {
+            var request = new GetUsersRequest(PerformedBy);
+            var users = _client.CallAsync(request).Result.ToArray();
+            return users;
+        }
+
+        private static void SetupRestClient()
+        {
+            Console.WriteLine("Setup RestClient from appsettings.json");
+
+            var section = new ConfigurationBuilder()
+                          .AddJsonFile("appsettings.json")
+                          .Build()
+                          .GetSection("RestClient");
+
+            _client = new ApiClientBuilder()
+                      .ConfigureFromConfigSection(section)
+                      .Build();
+        }
+
+        private static UserDetailsResponse GetUserDetailsResponse(string login)
+        {
+            var detailsRequest = new GetUserDetailsRequest(login, PerformedBy);
+            var details = _client.CallAsync(detailsRequest).Result;
+            return details;
+        }
+    }
+}

--- a/examples/ConsoleExample/appsettings.json
+++ b/examples/ConsoleExample/appsettings.json
@@ -1,0 +1,15 @@
+﻿{
+    "RestClient": {
+        "ClientId": "CLIENT",
+        "ClientSecret": "SECRET",
+        "Authentication": "oauth2",
+        "Issuer": "https://demo.identityserver.io/connect/token",
+        "Scopes": "openid profile api",
+        "Apis": {
+            "Github": {
+                "BaseUrl": "https://api.github.com/",
+                "Audience": "github"
+            }
+        }
+    }
+}

--- a/examples/ContractsExamples/ContractsExamples.csproj
+++ b/examples/ContractsExamples/ContractsExamples.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Collector.Common.RestClient\Collector.Common.RestClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/ContractsExamples/github/GithubApiBaseRequest.cs
+++ b/examples/ContractsExamples/github/GithubApiBaseRequest.cs
@@ -1,0 +1,31 @@
+﻿namespace ContractsExamples.github
+{
+    using Collector.Common.RestContracts;
+    using Collector.Common.RestContracts.Interfaces;
+
+    using Newtonsoft.Json;
+
+    public abstract class GithubApiBaseRequest<TResourceIdentifier, TResponse> : RequestBase<TResourceIdentifier, TResponse>
+        where TResourceIdentifier : class, IResourceIdentifier where TResponse : class
+    {
+        protected GithubApiBaseRequest(TResourceIdentifier resourceIdentifier, string performedBy)
+            : base(resourceIdentifier)
+        {
+        }
+
+        public override string GetConfigurationKey()
+        {
+            return "Github";
+        }
+
+        protected TResponseType ParseResponse<TResponseType>(string content)
+        {
+            var settings = new JsonSerializerSettings
+                           {
+                               DateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind,
+                               DateParseHandling = DateParseHandling.DateTimeOffset
+                           };
+            return JsonConvert.DeserializeObject<TResponseType>(content, settings);
+        }
+    }
+}

--- a/examples/ContractsExamples/github/UserDetails/GetUserDetailsRequest.cs
+++ b/examples/ContractsExamples/github/UserDetails/GetUserDetailsRequest.cs
@@ -1,0 +1,21 @@
+﻿namespace ContractsExamples.github.UserDetails
+{
+    using Collector.Common.RestContracts;
+    using Collector.Common.RestContracts.Interfaces;
+
+    public class GetUserDetailsRequest : GithubApiBaseRequest<UserDetailsResourceIdentifier, UserDetailsResponse>,
+        ISuccessfulResponseParser<UserDetailsResponse>
+    {
+        public GetUserDetailsRequest(string login, string performedBy)
+            : base(new UserDetailsResourceIdentifier(login), performedBy)
+        {
+        }
+
+        public override HttpMethod GetHttpMethod() => HttpMethod.GET;
+
+        public UserDetailsResponse ParseResponse(string content)
+        {
+            return base.ParseResponse<UserDetailsResponse>(content);
+        }
+    }
+}

--- a/examples/ContractsExamples/github/UserDetails/UserDetailsResourceIdentifier.cs
+++ b/examples/ContractsExamples/github/UserDetails/UserDetailsResourceIdentifier.cs
@@ -1,0 +1,16 @@
+﻿namespace ContractsExamples.github.UserDetails
+{
+    using Collector.Common.RestContracts;
+
+    public class UserDetailsResourceIdentifier : ResourceIdentifier
+    {
+        public UserDetailsResourceIdentifier(string login)
+        {
+            Login = login;
+        }
+
+        public override string Uri => $"users/{Login}";
+
+        public object Login { get; set; }
+    }
+}

--- a/examples/ContractsExamples/github/UserDetails/UserDetailsResponse.cs
+++ b/examples/ContractsExamples/github/UserDetails/UserDetailsResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace ContractsExamples.github.UserDetails
+{
+    public class UserDetailsResponse
+    {
+        public string Login { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/examples/ContractsExamples/github/Users/GetUsersRequest.cs
+++ b/examples/ContractsExamples/github/Users/GetUsersRequest.cs
@@ -1,0 +1,23 @@
+﻿namespace ContractsExamples.github.Users
+{
+    using System.Collections.Generic;
+
+    using Collector.Common.RestContracts;
+    using Collector.Common.RestContracts.Interfaces;
+
+    public class GetUsersRequest : GithubApiBaseRequest<UsersResourceIdentifier, List<UsersResponse>>,
+        ISuccessfulResponseParser<List<UsersResponse>>
+    {
+        public GetUsersRequest(string performedBy)
+            : base(new UsersResourceIdentifier(), performedBy)
+        {
+        }
+
+        public override HttpMethod GetHttpMethod() => HttpMethod.GET;
+        
+        public List<UsersResponse> ParseResponse(string content)
+        {
+            return base.ParseResponse<List<UsersResponse>>(content);
+        }
+    }
+}

--- a/examples/ContractsExamples/github/Users/UsersResourceIdentifier.cs
+++ b/examples/ContractsExamples/github/Users/UsersResourceIdentifier.cs
@@ -1,0 +1,9 @@
+﻿namespace ContractsExamples.github.Users
+{
+    using Collector.Common.RestContracts;
+
+    public class UsersResourceIdentifier : ResourceIdentifier
+    {
+        public override string Uri => "users";
+    }
+}

--- a/examples/ContractsExamples/github/Users/UsersResponse.cs
+++ b/examples/ContractsExamples/github/Users/UsersResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace ContractsExamples.github.Users
+{
+    public class UsersResponse
+    {
+        public string Login { get; set; }
+    }
+}

--- a/src/Collector.Common.RestClient/ApiClientBuilder.cs
+++ b/src/Collector.Common.RestClient/ApiClientBuilder.cs
@@ -16,7 +16,7 @@
             foreach (var baseUrlSetting in ConfigurationManager.AppSettings.AllKeys.Where(k => k.StartsWith("RestClient:")).Where(k => k.EndsWith(".BaseUrl")))
             {
                 var contractKey = baseUrlSetting.Split(':').Last().Split('.').First();
-                ConfigureContractKey(contractKey, new AppConfigReader(contractKey));
+                WithConfiguration(contractKey, () => new AppConfigReader(contractKey));
             }
 
             return this;
@@ -43,7 +43,7 @@
         {
             foreach (var subSection in configurationSection.GetSection("Apis").GetChildren())
             {
-                ConfigureContractKey(subSection.Key, new SectionConfigReader(configurationSection, subSection));
+                WithConfiguration(subSection.Key, () => new SectionConfigReader(configurationSection, subSection));
             }
 
             return this;

--- a/src/Collector.Common.RestClient/Collector.Common.RestClient.csproj
+++ b/src/Collector.Common.RestClient/Collector.Common.RestClient.csproj
@@ -5,7 +5,7 @@
     <PackageId>Collector.Common.RestClient</PackageId>
     <Company>Collector Bank AB</Company>
     <Product>Collector.Common.RestClient</Product>
-    <Version>16.0.0</Version>
+    <Version>16.1.0</Version>
     <Description>Rest API client to use with RestContracts and RestApi</Description>
     <Authors>Team Houdini, Team Heimdal</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/Collector.Common.RestClient/RestSharpClient/RestSharpRequestHandler.cs
+++ b/src/Collector.Common.RestClient/RestSharpClient/RestSharpRequestHandler.cs
@@ -1,9 +1,11 @@
 ﻿namespace Collector.Common.RestClient.RestSharpClient
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Reflection;
     using System.Threading.Tasks;
 
     using Collector.Common.RestClient.Exceptions;
@@ -99,8 +101,7 @@
             }
         }
 
-        private static RestRequest CreateRestRequest<TResourceIdentifier>(RequestBase<TResourceIdentifier> request)
-            where TResourceIdentifier : class, IResourceIdentifier
+        private static RestRequest CreateRestRequest<TResourceIdentifier>(RequestBase<TResourceIdentifier> request) where TResourceIdentifier : class, IResourceIdentifier
         {
             var restRequest = new RestRequest(request.GetResourceIdentifier().Uri, GetMethod(request.GetHttpMethod()))
                               {

--- a/test/Collector.Common.RestClient.Unittests/ApiClientBuilder_Test.cs
+++ b/test/Collector.Common.RestClient.Unittests/ApiClientBuilder_Test.cs
@@ -23,7 +23,6 @@
                 .GetSection("RestClient");
 
             var provider = new ApiClientBuilder()
-                .RegisterAuthenticator("MyCustomAuth", configReader => new Oauth2AuthorizationConfiguration("clientId", "secret", "aud", "issuer", "scopes"))
                 .ConfigureFromConfigSection(section)
                 .Build();
 #elif NET452

--- a/test/Collector.Common.RestClient.Unittests/ApiClientBuilder_Test.cs
+++ b/test/Collector.Common.RestClient.Unittests/ApiClientBuilder_Test.cs
@@ -16,6 +16,8 @@
         [Test]
         public void It_can_be_configured_through_either_configuration_sections_or_app_settings()
         {
+            var clientId = Guid.NewGuid().ToString();
+
 #if NETCOREAPP2_0
             var section = new ConfigurationBuilder()
                 .AddJsonFile("configuration.json")
@@ -28,6 +30,7 @@
 #elif NET452
             var provider = new ApiClientBuilder()
                 .ConfigureFromAppSettings()
+                .RegisterAuthenticator("MyCustomAuth", configReader => new Oauth2AuthorizationConfiguration(clientId, "secret", "aud", "issuer", "scopes"))
                 .Build();
 #endif
             Assert.NotNull(provider);

--- a/test/Collector.Common.RestClient.Unittests/ApiClientBuilder_Test.cs
+++ b/test/Collector.Common.RestClient.Unittests/ApiClientBuilder_Test.cs
@@ -18,11 +18,12 @@
         {
 #if NETCOREAPP2_0
             var section = new ConfigurationBuilder()
-                .AddJsonFile("configuration.json")
+                .AddJsonFile("appsettings.json")
                 .Build()
                 .GetSection("RestClient");
 
             var provider = new ApiClientBuilder()
+                .RegisterAuthenticator("MyCustomAuth", configReader => new Oauth2AuthorizationConfiguration("clientId", "secret", "aud", "issuer", "scopes"))
                 .ConfigureFromConfigSection(section)
                 .Build();
 #elif NET452
@@ -52,7 +53,7 @@
 #elif NET452
             var provider = new ApiClientBuilder()
                            .ConfigureFromAppSettings()
-                           .RegisterAuthenticator("MyCustomAuth", configReader => new Oauth2AuthorizationConfiguration(clientId, "secret", "aud", "issuer", "scopes"))
+                           .RegisterAuthenticator("MyOther", configReader => new Oauth2AuthorizationConfiguration(clientId, "secret", "aud", "issuer", "scopes"))
                            .Build();
 #endif
 

--- a/test/Collector.Common.RestClient.Unittests/ApiClientBuilder_Test.cs
+++ b/test/Collector.Common.RestClient.Unittests/ApiClientBuilder_Test.cs
@@ -18,7 +18,7 @@
         {
 #if NETCOREAPP2_0
             var section = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json")
+                .AddJsonFile("configuration.json")
                 .Build()
                 .GetSection("RestClient");
 
@@ -53,7 +53,7 @@
 #elif NET452
             var provider = new ApiClientBuilder()
                            .ConfigureFromAppSettings()
-                           .RegisterAuthenticator("MyOther", configReader => new Oauth2AuthorizationConfiguration(clientId, "secret", "aud", "issuer", "scopes"))
+                           .RegisterAuthenticator("MyCustomAuth", configReader => new Oauth2AuthorizationConfiguration(clientId, "secret", "aud", "issuer", "scopes"))
                            .Build();
 #endif
 

--- a/test/Collector.Common.RestClient.Unittests/Client/RestSharpRequestHandler_Test.cs
+++ b/test/Collector.Common.RestClient.Unittests/Client/RestSharpRequestHandler_Test.cs
@@ -34,9 +34,9 @@
         {
             _fixture = new Fixture();
             _restClient = new RestClient_Fake
-                              {
-                                  BaseUrl = _fixture.Create<Uri>()
-                              };
+            {
+                BaseUrl = _fixture.Create<Uri>()
+            };
             _restRequest = new RestRequest_Fake();
             _restClientWrapper = new RestSharpClientWrapper_Fake();
 
@@ -59,7 +59,7 @@
         public async Task When_executing_call_async_the_rest_request_has_the_expected_uri()
         {
             var request = new RequestWithResponse(new DummyResourceIdentifier()) { StringProperty = _fixture.Create<string>() };
-         
+
 
             await _sut.CallAsync(request);
 
@@ -140,6 +140,28 @@
             Assert.AreEqual(expectedError.Message, exception.Error.Message);
             CollectionAssert.AreEqual(expectedError.Errors.Select(e => e.Message), exception.Error.Errors.Select(e => e.Message));
             CollectionAssert.AreEqual(expectedError.Errors.Select(e => e.Reason), exception.Error.Errors.Select(e => e.Reason));
+        }
+
+        [Test]
+        public async Task When_executing_call_async_for_get_request_with_parameter_array_value_then_expect_same_name_multiple_times_in_parameters()
+        {
+            var values = new[] { string.Empty, "value" };
+            var request = new GetRequestWithoutResponse(new DummyResourceIdentifier()) { ArrayProperty = values };
+
+            await _sut.CallAsync(request);
+
+            Assert.True(_restClientWrapper.LastRequest.Parameters.Count(p => p.Name == "ArrayProperty") == values.Length);
+        }
+
+        [Test]
+        public async Task When_executing_call_async_for_get_request_with_parameter_array_value_containing_null_then_expect_parameter_not_in_parameters()
+        {
+            var values = new string[] { null, null, null };
+            var request = new GetRequestWithoutResponse(new DummyResourceIdentifier()) { ArrayProperty = values };
+
+            await _sut.CallAsync(request);
+
+            Assert.True(_restClientWrapper.LastRequest.Parameters.Count(p => p.Name == "ArrayProperty") == 0);
         }
 
         private void ConfigureRestSharpFakeWrapper(Error error = null, IEnumerable<ErrorInfo> errorInfos = null, HttpStatusCode statusCode = HttpStatusCode.BadRequest)

--- a/test/Collector.Common.RestClient.Unittests/Fakes/FakeRequests.cs
+++ b/test/Collector.Common.RestClient.Unittests/Fakes/FakeRequests.cs
@@ -55,6 +55,31 @@
         }
     }
 
+    public class GetRequestWithoutResponse : RequestBase<DummyResourceIdentifier>
+    {
+        public GetRequestWithoutResponse(DummyResourceIdentifier resourceIdentifier)
+            : base(resourceIdentifier)
+        {
+        }
+
+        public string[] ArrayProperty { get; set; }
+
+        public override HttpMethod GetHttpMethod() => HttpMethod.GET;
+
+        public override string GetConfigurationKey()
+        {
+            return "Test";
+        }
+
+        protected override IEnumerable<string> ValidateRequest()
+        {
+            if (ArrayProperty == null)
+                return new[] { "Array property is required" };
+
+            return Enumerable.Empty<string>();
+        }
+    }
+
     public class DummyResourceIdentifier : ResourceIdentifier
     {
         public override string Uri => "api.url.com";

--- a/test/Collector.Common.RestClient.Unittests/app.config
+++ b/test/Collector.Common.RestClient.Unittests/app.config
@@ -9,7 +9,7 @@
     <add key="RestClient:MyApi.Audience" value="https://my-api.com"/>
     <add key="RestClient:MyApi.BaseUrl" value="https://my-api.com"/>
     <add key="RestClient:MyApi.Timeout" value="00:00:30"/>
-    <add key="RestClient:MyApi.Authentication" value="MyOther"/>
+    <add key="RestClient:MyApi.Authentication" value="MyCustomAuth"/>
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/test/Collector.Common.RestClient.Unittests/app.config
+++ b/test/Collector.Common.RestClient.Unittests/app.config
@@ -9,6 +9,7 @@
     <add key="RestClient:MyApi.Audience" value="https://my-api.com"/>
     <add key="RestClient:MyApi.BaseUrl" value="https://my-api.com"/>
     <add key="RestClient:MyApi.Timeout" value="00:00:30"/>
+    <add key="RestClient:MyApi.Authentication" value="MyCustomAuth"/>
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/test/Collector.Common.RestClient.Unittests/app.config
+++ b/test/Collector.Common.RestClient.Unittests/app.config
@@ -9,6 +9,7 @@
     <add key="RestClient:MyApi.Audience" value="https://my-api.com"/>
     <add key="RestClient:MyApi.BaseUrl" value="https://my-api.com"/>
     <add key="RestClient:MyApi.Timeout" value="00:00:30"/>
+    <add key="RestClient:MyApi.Authentication" value="MyOther"/>
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/test/Collector.Common.RestClient.Unittests/app.config
+++ b/test/Collector.Common.RestClient.Unittests/app.config
@@ -9,7 +9,6 @@
     <add key="RestClient:MyApi.Audience" value="https://my-api.com"/>
     <add key="RestClient:MyApi.BaseUrl" value="https://my-api.com"/>
     <add key="RestClient:MyApi.Timeout" value="00:00:30"/>
-    <add key="RestClient:MyApi.Authentication" value="MyCustomAuth"/>
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/test/Collector.Common.RestClient.Unittests/appsettings.json
+++ b/test/Collector.Common.RestClient.Unittests/appsettings.json
@@ -3,21 +3,20 @@
     "ClientId": "my_client_id",
     "ClientSecret": "my_client_secret",
     "Authentication": "oauth2",
-    "Authenticsdfsdfsdfation": "sdfsfdsdf",
     "Issuer": "my_issuer.com",
 
     "Apis": {
-      "MyApi": {
-        "Audience": "https://my-api.com",
-        "BaseUrl": "https://my-api.com",
-        "Timeout": "00:00:30"
-      },
-      "MyCustomAuthApi": {
-        "Audience": "https://my-custom-auth--api.com",
-        "BaseUrl": "https://my-custom-auth-api.com",
-        "Timeout": "00:00:30",
-        "Authentication": "MyCustomAuth"
-      }
+        "MyApi": {
+            "Audience": "https://my-api.com",
+            "BaseUrl": "https://my-api.com",
+            "Timeout": "00:00:30"
+        },
+        "MyCustomAuthApi": {
+            "Audience": "https://my-custom-auth--api.com",
+            "BaseUrl": "https://my-custom-auth-api.com",
+            "Timeout": "00:00:30",
+            "Authentication": "MyCustomAuth"
+        }
     }
   }
 }

--- a/test/Collector.Common.RestClient.Unittests/appsettings.json
+++ b/test/Collector.Common.RestClient.Unittests/appsettings.json
@@ -1,23 +1,23 @@
 ﻿{
-    "RestClient": {
-        "ClientId": "my_client_id",
-        "ClientSecret": "my_client_secret",
-        "Authentication": "oauth2",
-        "Authenticsdfsdfsdfation": "sdfsfdsdf",
-        "Issuer": "my_issuer.com",
+  "RestClient": {
+    "ClientId": "my_client_id",
+    "ClientSecret": "my_client_secret",
+    "Authentication": "oauth2",
+    "Authenticsdfsdfsdfation": "sdfsfdsdf",
+    "Issuer": "my_issuer.com",
 
-        "Apis": {
-            "MyApi": {
-                "Audience": "https://my-api.com",
-                "BaseUrl": "https://my-api.com",
-                "Timeout": "00:00:30"
-            },
-            "MyCustomAuthApi": {
-                "Audience": "https://my-custom-auth--api.com",
-                "BaseUrl": "https://my-custom-auth-api.com",
-                "Timeout": "00:00:30",
-                "Authentication": "MyCustomAuth"
-            }
-        }
+    "Apis": {
+      "MyApi": {
+        "Audience": "https://my-api.com",
+        "BaseUrl": "https://my-api.com",
+        "Timeout": "00:00:30"
+      },
+      "MyCustomAuthApi": {
+        "Audience": "https://my-custom-auth--api.com",
+        "BaseUrl": "https://my-custom-auth-api.com",
+        "Timeout": "00:00:30",
+        "Authentication": "MyCustomAuth"
+      }
     }
+  }
 }

--- a/test/Collector.Common.RestClient.Unittests/appsettings.json
+++ b/test/Collector.Common.RestClient.Unittests/appsettings.json
@@ -1,22 +1,23 @@
 ﻿{
-  "RestClient": {
-    "ClientId": "my_client_id",
-    "ClientSecret": "my_client_secret",
-    "Authentication": "oauth2",
-    "Issuer": "my_issuer.com",
+    "RestClient": {
+        "ClientId": "my_client_id",
+        "ClientSecret": "my_client_secret",
+        "Authentication": "oauth2",
+        "Authenticsdfsdfsdfation": "sdfsfdsdf",
+        "Issuer": "my_issuer.com",
 
-    "Apis": {
-        "MyApi": {
-            "Audience": "https://my-api.com",
-            "BaseUrl": "https://my-api.com",
-            "Timeout": "00:00:30"
-        },
-        "MyCustomAuthApi": {
-            "Audience": "https://my-custom-auth--api.com",
-            "BaseUrl": "https://my-custom-auth-api.com",
-            "Timeout": "00:00:30",
-            "Authentication": "MyCustomAuth"
+        "Apis": {
+            "MyApi": {
+                "Audience": "https://my-api.com",
+                "BaseUrl": "https://my-api.com",
+                "Timeout": "00:00:30"
+            },
+            "MyCustomAuthApi": {
+                "Audience": "https://my-custom-auth--api.com",
+                "BaseUrl": "https://my-custom-auth-api.com",
+                "Timeout": "00:00:30",
+                "Authentication": "MyCustomAuth"
+            }
         }
     }
-  }
 }


### PR DESCRIPTION
Adds every value of an array as an own key/value pair.

BEFORE:
string[] categories = ["Category A", "Category B"]
/api/search?categories=SystemString[]

WITH FIX:
string[] categories = ["Category A", "Category B"]
/api/search?categories=Category A&categories=Category B