### PR TITLE
Add support for masking request and response logs

### DIFF
--- a/src/Collector.Common.RestClient/Collector.Common.RestClient.csproj
+++ b/src/Collector.Common.RestClient/Collector.Common.RestClient.csproj
@@ -5,7 +5,7 @@
     <PackageId>Collector.Common.RestClient</PackageId>
     <Company>Collector Bank AB</Company>
     <Product>Collector.Common.RestClient</Product>
-    <Version>16.0.1</Version>
+    <Version>16.1</Version>
     <Description>Rest API client to use with RestContracts and RestApi</Description>
     <Authors>Team Houdini, Team Heimdal</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/Collector.Common.RestClient/Logging/RequestLogEntry.cs
+++ b/src/Collector.Common.RestClient/Logging/RequestLogEntry.cs
@@ -1,0 +1,14 @@
+﻿namespace Collector.Common.RestClient.Logging
+{
+    using RestSharp;
+
+    public class RequestLogEntry
+    {
+        public string RequestContent { get; set; }
+
+        public string HttpRequestUrl { get; set; }
+
+        public Method HttpRequestType { get; set; }
+
+    }
+}

--- a/src/Collector.Common.RestClient/Logging/ResponseLogEntry.cs
+++ b/src/Collector.Common.RestClient/Logging/ResponseLogEntry.cs
@@ -1,0 +1,25 @@
+﻿namespace Collector.Common.RestClient.Logging
+{
+    using System;
+
+    using RestSharp;
+
+    public class ResponseLogEntry
+    {
+        public Uri HttpRequestUrl { get; set; }
+
+        public Method HttpRequestType { get; set; }
+
+        public int StatusCode { get; set; }
+
+        public string MediaType { get; set; }
+
+        public int ResponseTimeMilliseconds { get; set; }
+
+        public int ResponseContentLength { get; set; }
+
+        public string RawResponseBody { get; set; }
+
+        public string ResponseBody { get; set; }
+    }
+}

--- a/src/Collector.Common.RestClient/RestSharpClient/RestSharpClientWrapper.cs
+++ b/src/Collector.Common.RestClient/RestSharpClient/RestSharpClientWrapper.cs
@@ -7,6 +7,7 @@
 
     using Collector.Common.RestClient.Authorization;
     using Collector.Common.RestClient.Exceptions;
+    using Collector.Common.RestClient.Logging;
     using Collector.Common.RestContracts.Interfaces;
 
     using Newtonsoft.Json;
@@ -23,19 +24,25 @@
         private readonly IDictionary<string, IAuthorizationHeaderFactory> _authorizationHeaderFactories;
         private readonly IDictionary<string, TimeSpan> _timeouts;
         private readonly Func<string, string> _configurationKeyDecorator;
+        private readonly Action<RequestLogEntry> _maskRequestLog;
+        private readonly Action<ResponseLogEntry> _maskResponseLog;
         private readonly ILogger _logger;
 
         public RestSharpClientWrapper(
-            IDictionary<string, Uri> baseUrlMappings, 
+            IDictionary<string, Uri> baseUrlMappings,
             IDictionary<string, IAuthorizationHeaderFactory> authorizationHeaderFactories,
             IDictionary<string, TimeSpan> timeouts,
             Func<string, string> configurationKeyDecorator,
-            ILogger logger)
+            ILogger logger,
+            Action<RequestLogEntry> maskRequestLog,
+            Action<ResponseLogEntry> maskResponseLog)
         {
             _baseUrlMappings = baseUrlMappings;
             _authorizationHeaderFactories = authorizationHeaderFactories;
             _timeouts = timeouts;
             _configurationKeyDecorator = configurationKeyDecorator;
+            _maskRequestLog = maskRequestLog;
+            _maskResponseLog = maskResponseLog;
             _logger = logger?.ForContext(GetType());
         }
 
@@ -45,9 +52,9 @@
                 throw new RestClientConfigurationException($"No mapping found for contract identifier : {contractKey}");
 
             var client = new RestClient
-                         {
-                             BaseUrl = _baseUrlMappings[contractKey],
-                         };
+            {
+                BaseUrl = _baseUrlMappings[contractKey],
+            };
 
             if (_authorizationHeaderFactories.ContainsKey(contractKey))
                 client.Authenticator = new RestSharpAuthenticator(_authorizationHeaderFactories[contractKey]);
@@ -85,49 +92,60 @@
 
         private void TryLogRequest(IRestRequest restRequest, IRequest request, IRestClient restClient, string configurationKey)
         {
+            if (_logger == null)
+                return;
+
             try
             {
-                var restClientLogProperty = new
-                                            {
-                                                RequestContent = restRequest.Method == Method.GET || restRequest.Method == Method.DELETE
+                var requestContent = restRequest.Method == Method.GET || restRequest.Method == Method.DELETE
                                                                      ? string.Empty
-                                                                     : JsonConvert.SerializeObject(request, Formatting.Indented),
-                                                HttpRequestUrl = restClient.BuildUri(restRequest).ToString(),
-                                                HttpRequestType = restRequest.Method
-                                            };
+                                                                     : JsonConvert.SerializeObject(request, Formatting.Indented);
+                var restClientLogProperty = new RequestLogEntry
+                {
+                    HttpRequestType = restRequest.Method,
+                    HttpRequestUrl = restClient.BuildUri(restRequest).ToString(),
+                    RequestContent = requestContent
+                };
 
-                _logger?.ForContext("RestClient", restClientLogProperty, destructureObjects: true)
-                       ?.Information("Rest request sent to {ConfigurationKey}", configurationKey);
+                _maskRequestLog?.Invoke(restClientLogProperty);
+
+                _logger.ForContext("RestClient", restClientLogProperty, destructureObjects: true)
+                       .Information("Rest request sent to {ConfigurationKey}", configurationKey);
             }
             catch (Exception e)
             {
-                _logger?.Warning(e, "There was a problem logging the rest request");
+                _logger.Warning(e, "There was a problem logging the rest request");
             }
         }
 
         private void TryLogResponse(IRestRequest restRequest, Stopwatch stopwatch, IRestResponse response, IRequest request, string configurationKey)
         {
+            if (_logger == null)
+                return;
+
             try
             {
                 var isJsonResponse = response.ContentType?.ToLower().Contains("application/json") ?? false;
-                var restClientLogProperty = new
-                                            {
-                                                HttpRequestUrl = response.ResponseUri,
-                                                HttpRequestType = restRequest.Method,
-                                                StatusCode = (int)response.StatusCode,
-                                                MediaType = response.ContentType,
-                                                ResponseTimeMilliseconds = (int)stopwatch.ElapsedMilliseconds,
-                                                ResponseContentLength = (int)response.ContentLength,
-                                                RawResponseBody = isJsonResponse ? response.Content : "Response not in json format",
-                                                ResponseBody = isJsonResponse ? GetFormatedResponseContent(response) : "Response not in json format"
-                                            };
+                var restClientLogProperty = new ResponseLogEntry
+                {
+                    HttpRequestUrl = response.ResponseUri,
+                    HttpRequestType = restRequest.Method,
+                    StatusCode = (int)response.StatusCode,
+                    MediaType = response.ContentType,
+                    ResponseTimeMilliseconds = (int)stopwatch.ElapsedMilliseconds,
+                    ResponseContentLength = (int)response.ContentLength,
+                    RawResponseBody = isJsonResponse ? response.Content : "Response not in json format",
+                    ResponseBody = isJsonResponse ? GetFormatedResponseContent(response) : "Response not in json format"
+                };
 
-                _logger?.ForContext("RestClient", restClientLogProperty, destructureObjects: true)
-                       ?.Information("Rest response recieved from {ConfigurationKey}", configurationKey);
+                _maskResponseLog?.Invoke(restClientLogProperty);
+
+                _logger.ForContext("RestClient", restClientLogProperty, destructureObjects: true)
+                       .Information("Rest response recieved from {ConfigurationKey}", configurationKey);
             }
             catch (Exception e)
             {
-                _logger?.Warning(e, "There was a problem logging the rest response");
+                _logger.Warning(e, "There was a problem logging the rest response");
             }
         }
 


### PR DESCRIPTION
Background:

We use common-restclient to communicate with a system that requires us to provide secrets in the request body. This system will also sometimes respond with shared secrets in the response body. This PR enables us to filter these values from the request and response log properties.

Usage:
```
 var client = new ApiClientBuilder()
                .WithLogger(Logger)
                .WithRequestLogMasking(requestLogEntry => requestLogEntry.RequestContent = "*")
                .WithResponseLogMasking(responseLogEntry =>
                {
                    responseLogEntry.RawResponseBody = "*";
                    responseLogEntry.ResponseBody = "*";
                })
                .Build();
```